### PR TITLE
Fix typo in RNASEQ docs

### DIFF
--- a/docs/usage/DEanalysis/rnaseq.md
+++ b/docs/usage/DEanalysis/rnaseq.md
@@ -8,7 +8,7 @@ In order to carry out a RNA-Seq analysis we will use the nf-core pipeline [rnase
 
 ## Overview
 
-The pipeline is organised following the diffent blocks shown below: pre-processing, traditional alignment (or lightweight alignment) and quantification, post-processing and final QC.
+The pipeline is organised following the different blocks shown below: pre-processing, traditional alignment (or lightweight alignment) and quantification, post-processing and final QC.
 
 <figure markdown="span">
   ![metromap](./img/nf-core-rnaseq_metro_map_grey.png){ width="1000"}


### PR DESCRIPTION
## Summary
- correct typo in the pipeline overview of the DE analysis documentation

## Testing
- `pre-commit run --files docs/usage/DEanalysis/rnaseq.md`

------
https://chatgpt.com/codex/tasks/task_e_68486738a008832f8da334563bee9cc9